### PR TITLE
Update to current Delta syntax

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -5,9 +5,9 @@
 		"description": "",
 		"scope": "source.delta"
 	},
-	"func": {
-		"prefix": "func",
-		"body": "\nfunc ${1:name}(${2:arguments}) -> ${3:ReturnType} {\n\t$4\n}\n",
+	"def": {
+		"prefix": "def",
+		"body": "\ndef ${1:name}(${2:arguments}): ${3:ReturnType} {\n\t$4\n}\n",
 		"description": "",
 		"scope": "source.delta"
 	},

--- a/syntaxes/delta.tmLanguage
+++ b/syntaxes/delta.tmLanguage
@@ -74,7 +74,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(class|deinit|enum|func|import|init|undefined|let|struct|typealias|var|break|case|continue|do|else|if|in|for|return|switch|while|mutating|mutable|null)\b</string>
+			<string>\b(class|deinit|enum|def|import|init|undefined|let|struct|typealias|var|break|case|continue|do|else|if|in|for|return|switch|while|mutating|mutable|null)\b</string>
 			<key>name</key>
 			<string>keyword.reserved.delta</string>
 		</dict>


### PR DESCRIPTION
- Rename func to def.
- Use colon for function return type annotation.